### PR TITLE
Add missing parameter to call in methods slide of lecture 01

### DIFF
--- a/01/content.md
+++ b/01/content.md
@@ -506,7 +506,9 @@ impl Point {
 
 fn main() {
     let p = Point { x: 1, y: 2 };
-    p.distance();
+    let q = Point { x: 3, y: 7 };
+
+    println!("Distance: {}", p.distance(q));
 }
 ```
 


### PR DESCRIPTION
The call to the distance method did not have any parameter provided. Created another point and passed this as parameter.

Additionally, I suggest printing the value and have made this change take care of that as well.
