### PR TITLE
Fix incorrectly rounded pi

### DIFF
--- a/02/content.md
+++ b/02/content.md
@@ -680,7 +680,7 @@ let p = Pizza(vec![1, 2, 3, 4]);
 ### `static`
 
 ```rust
-static PI: f32 = 3.1419;
+static PI: f32 = 3.1416;
 ```
 
 - Static variables have `'static` lifetimes.

--- a/02/content.md
+++ b/02/content.md
@@ -713,7 +713,7 @@ static mut counter: i32 = 0;
 ### `const`
 
 ```rust
-const PI: f32 = 3.1419;
+const PI: f32 = 3.1416;
 ```
 
 - Defines constants that live for the duration of the program.


### PR DESCRIPTION
Pi rounded to four decimal places is equal to 3.1416, not 3.1419. This might be the most insignificant pull-request posted by anyone ever but I noticed and hope that this pull-request doesn't bother you.

PS: I enjoyed the variable named `life_of_pi` in this slide very much.
