### PR TITLE
Removed semicolon from if branch

### DIFF
--- a/00/content.md
+++ b/00/content.md
@@ -573,7 +573,7 @@ if x > 0 {
 
 ```rust
 if x <= 0 {
-    println!("Too small!");
+    println!("Too small!")
 }
 ```
 


### PR DESCRIPTION
The slide details the importance of having the type of the if expression be equal, with an example using `println!`. However, it also was semicolon-terminated, so the actual expression used wouldn't matter, as long as it compiled. By removing the semicolon, I believe it makes it more obvious that the type of the expression in the if branch must be `()` if there is no else branch.

To be clear, replacing `println!("foo");` with `4 * 4;` will compile, but when the semicolons are removed from both expressions, only the former will actually compile.
